### PR TITLE
Fix image comment inserts

### DIFF
--- a/image_comment_add.php
+++ b/image_comment_add.php
@@ -4,9 +4,9 @@
     include "includes/functions.php";
 
     $image_id = $_POST['image_id'];
-    $comment = mysqli_real_escape_string($link,$_POST['comment_text']);
+    $comment = mysqli_real_escape_string($link, $_POST['comment_text']);
 
-    $add_comment = "INSERT INTO video_comments (video_id, video_comment, comment_date) VALUES ($video_id,'$comment',now())";
+    $add_comment = "INSERT INTO picture_comments (pic_id, comment, comment_date) VALUES ($image_id,'$comment',now())";
     $result_comments = mysqli_query($link, $add_comment) or die(mysqli_error($link));
 
 

--- a/image_comment_create.php
+++ b/image_comment_create.php
@@ -1,12 +1,11 @@
 <?php
 
     include("includes/dbconnect.php");
-    $text = mysqli_real_escape_string($link,$_POST['picture_comment']);
-    $picture_id=$_POST['image_id'];
-    $picture_comment = $_POST['comment_text'];
+    $image_id=$_POST['image_id'];
+    $comment = mysqli_real_escape_string($link, $_POST['comment_text']);
 
-    //echo $picture_id;
- $sql="INSERT into picture_comments (pic_id,comment, comment_date ) VALUES ($picture_id, ' $picture_comment', now())";
+    //echo $image_id;
+ $sql="INSERT INTO picture_comments (pic_id, comment, comment_date) VALUES ($image_id,'$comment', now())";
   $result=mysqli_query($link, $sql) or die(mysqli_error($link));
 
 

--- a/image_comment_update.php
+++ b/image_comment_update.php
@@ -4,5 +4,5 @@ include "includes/functions.php";
 $comm_id=$_GET['comm_id'];
 $comment = mysqli_real_escape_string($link, $_GET['comment']);
 
-$sql="UPDATE video_comments SET video_comment = '$comment' WHERE comm_id=$comm_id";
+$sql="UPDATE picture_comments SET comment = '$comment' WHERE comm_id=$comm_id";
 $result_comments = mysqli_query($link, $sql) or die(mysqli_error($link));

--- a/picture_update_comment.php
+++ b/picture_update_comment.php
@@ -4,6 +4,5 @@ include "includes/functions.php";
 $comm_id=$_GET['comm_id'];
 $comment = mysqli_real_escape_string($link, $_GET['comment']);
 
-$sql="UPDATE picture_comments SET picture_comment = '$comment' WHERE comm_id=$comm_id";
-echo $sql;
+$sql="UPDATE picture_comments SET comment = '$comment' WHERE comm_id=$comm_id";
 $result_comments = mysqli_query($link, $sql) or die(mysqli_error($link));


### PR DESCRIPTION
## Summary
- fix incorrect table/column and variable names when adding or updating picture comments

## Testing
- `php -l image_comment_add.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685062410e548321b61742f82d20dfb2