### PR TITLE
Fix search tag input attribute typo

### DIFF
--- a/videos.php
+++ b/videos.php
@@ -193,7 +193,7 @@
                     </div>
 
                     <div class="video_tags_map">
-                        <input type="text" namae="search_tag" placeholder="Search a tag" autocomplete="off">
+                        <input type="text" name="search_tag" placeholder="Search a tag" autocomplete="off">
                         <?php 
                             $get_videos_tags = "SELECT a.tag_id,b.tag_name from video_tags a, tags_list b WHERE a.tag_id NOT IN (0) and a.tag_id = b.tag_id GROUP BY b.tag_name ORDER BY b.tag_name ASC";
                             $result_tags=mysqli_query($link, $get_videos_tags);


### PR DESCRIPTION
## Summary
- fix a typo in `videos.php` so the search tag input uses `name="search_tag"`

## Testing
- `grep -n search_tag videos.php`

------
https://chatgpt.com/codex/tasks/task_e_6850641923a08321b0c0f3062b61b248