### PR TITLE
Fix variable reference in favorites script

### DIFF
--- a/video_add_to_favorites.php
+++ b/video_add_to_favorites.php
@@ -1,14 +1,13 @@
-<?php include "includes/dbconnect.php";
-		  $video_id=intval($_POST['video_id']);
-          $video_name=mysqli_real_escape_string($link, $_POST['video_name']);
-          $sql="UPDATE videos set is_favorite=1 where video_id=$video_id";
-          $result = mysqli_query($link, $sql) or die("MySQLi ERROR: ".mysqli_error($link));
+<?php
+include "includes/dbconnect.php";
 
-          //wall
-          
-        
-          
-          $diary_text="Minecraft IS: video s nazvom $video_name bolo pridane medzi oblubene videa";
-          $sql="INSERT INTO app_log (diary_text, date_added) VALUES ('$diary_text',now())";
-          result = mysqli_query($link, $sql) or die("MySQLi ERROR: ".mysqli_error($link));
-          
+$video_id = intval($_POST['video_id']);
+$video_name = mysqli_real_escape_string($link, $_POST['video_name']);
+$sql = "UPDATE videos SET is_favorite = 1 WHERE video_id = $video_id";
+$result = mysqli_query($link, $sql) or die("MySQLi ERROR: " . mysqli_error($link));
+
+// Create entry in application log
+$diary_text = "Minecraft IS: video s nazvom $video_name bolo pridane medzi oblubene videa";
+$sql = "INSERT INTO app_log (diary_text, date_added) VALUES ('$diary_text', now())";
+$result = mysqli_query($link, $sql) or die("MySQLi ERROR: " . mysqli_error($link));
+


### PR DESCRIPTION
## Summary
- clean up `video_add_to_favorites.php`
- correct variable name when inserting into application log

## Testing
- `php -l video_add_to_favorites.php`

------
https://chatgpt.com/codex/tasks/task_e_685065e9ac94832198082af070ffd2c5