### PR TITLE
Add Router unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ example.txt
 backups/db-backup-1742914047-c8aa30a5c6837aebd5c17b0302c3aeae.sql
 /backups
 includes/dbconnect.php
+.phpunit.result.cache
 .vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Minecraft PHP Utilities
+
+This repository contains various PHP scripts used in a Minecraft-related project.
+
+## Running Tests
+
+The project uses [PHPUnit](https://phpunit.de/) for unit testing. Ensure PHP and PHPUnit are installed on your system. On Ubuntu you can install them with:
+
+```bash
+sudo apt-get update
+sudo apt-get install php phpunit
+```
+
+Execute the test suite from the project root:
+
+```bash
+phpunit
+```
+

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,0 +1,33 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RouterTest extends TestCase
+{
+    private $router;
+
+    protected function setUp(): void
+    {
+        // Suppress output and warnings from router.php when included
+        $_SERVER['REQUEST_URI'] = '/no-route';
+        $prevHandler = set_error_handler(function () {});
+        ob_start();
+        require_once __DIR__ . '/../router.php';
+        ob_end_clean();
+        restore_error_handler();
+
+        // Create fresh instance for testing
+        $this->router = new Router();
+    }
+
+    public function testRouteExecutesHandler()
+    {
+        $handlerFile = __DIR__ . '/dummy_handler.php';
+        $this->router->addRoute('/test', $handlerFile);
+
+        ob_start();
+        $this->router->route('/test');
+        $output = ob_get_clean();
+
+        $this->assertEquals('handled', trim($output));
+    }
+}

--- a/tests/dummy_handler.php
+++ b/tests/dummy_handler.php
@@ -1,0 +1,1 @@
+<?php echo "handled"; ?>


### PR DESCRIPTION
## Summary
- add PHPUnit test verifying that Router executes a registered handler
- add dummy handler for the test
- document how to run the tests with phpunit
- ignore phpunit result cache

## Testing
- `phpunit tests/RouterTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68506a5862ec8321953d272133a60219