### PR TITLE
Fix search typo in JS and HTML

### DIFF
--- a/js/modpack_videos.js
+++ b/js/modpack_videos.js
@@ -135,7 +135,7 @@ modal_comm_input.addEventListener("keydown", function(event) {
 
 
 
-    //clear serch input
+    //clear search input
     //var search_wrap = document.querySelector(".search_wrap");
     var search_input=document.querySelector(".search_wrap input");
     var clear_button= document.querySelector(".search_wrap button");

--- a/js/videos.js
+++ b/js/videos.js
@@ -192,7 +192,7 @@ modal_modpack_input.addEventListener("input", function(){
 
 
 
-    //clear serch input
+    //clear search input
     //var search_wrap = document.querySelector(".search_wrap");
 
     clear_button.addEventListener("click", function(){

--- a/modpack.php
+++ b/modpack.php
@@ -79,7 +79,7 @@ if(isset($_POST['add_daily_note'])){
           </div>    
           <div class="popup_mods_list">
             <header>
-              <input type="text" name="serch_mod" onkeyup="popup_search_mod(this.value);" autocomplete="off" spellcheck="false" placeholder="search mod(s) here...">
+              <input type="text" name="search_mod" onkeyup="popup_search_mod(this.value);" autocomplete="off" spellcheck="false" placeholder="search mod(s) here...">
               <button class='button blue_button' onclick="reload_modal_mods()"><i class="fas fa-sync-alt"></i></button>
               <button class='button blue_button' onclick="hide_popup()"><i class='fa fa-times'></i></button>
             </header>


### PR DESCRIPTION
## Summary
- fix 'serch' typo in videos.js and modpack_videos.js comments
- rename HTML `serch_mod` input name to `search_mod` in modpack.php

## Testing
- `grep -R "serch" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68506a580af0832194baa68db1c5f302