### PR TITLE
Fix modpack modal input

### DIFF
--- a/js/modpack_videos.js
+++ b/js/modpack_videos.js
@@ -107,7 +107,7 @@ modal_comm_input.addEventListener("keydown", function(event) {
 
     const modal_modpack_input = document.querySelector(".inner_modpack_layer input");
     modal_modpack_input.addEventListener("keydown", function(event) {
-    if (event.key == "Enter" && modal_modal_input.value !=="") {
+    if (event.key == "Enter" && modal_modpack_input.value !=="") {
         if(modal_modpack_input.value=="")
         //alert(modal_modpack_input.value);
         createNewModpack(modal_modpack_input.value)


### PR DESCRIPTION
## Summary
- fix keydown check to use `modal_modpack_input`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506a56ece0832190d4229187c8a6ff